### PR TITLE
Update Laravel 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.0.x"
+        "illuminate/support": "4.1.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Change the dependencies as there is no need to limit the illuminate/support version to 4.0.*.

Adding the following to composer.json allows this repo to be used instead with no issue.

```
    "repositories": [
        {
            "type": "git",
            "url": "git://github.com/DouglasMedeiros/tagcloud.git"
        }
    ]
```
